### PR TITLE
Removed 'reversed' from intToLittleEndianArray

### DIFF
--- a/lib/src/ftms/characteristic/machine/control_point/machine_control_point.dart
+++ b/lib/src/ftms/characteristic/machine/control_point/machine_control_point.dart
@@ -72,7 +72,7 @@ class MachineControlPoint {
     List<int> writeData = [opCode.value];
     if (parameter != null) {
       writeData.addAll(
-          Utils.intToLittleEndianArray(parameter!.value, parameter!.size));
+          Utils.intToLittleEndianArray(parameter!.value, parameter!.size).reversed);
     }
     return writeData;
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -20,7 +20,7 @@ class Utils {
     ByteData byteData = ByteData(length * 4);
     byteData.setInt32(0, value, Endian.little);
     List<int> byteArray = byteData.buffer.asUint8List();
-    return List<int>.from(byteArray.getRange(0, length).toList());
+    return List<int>.from(byteArray.getRange(0, length).toList().reversed);
   }
 
   static String dataToBinaryFlags(intArray, {int count = 2}) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -20,7 +20,7 @@ class Utils {
     ByteData byteData = ByteData(length * 4);
     byteData.setInt32(0, value, Endian.little);
     List<int> byteArray = byteData.buffer.asUint8List();
-    return List<int>.from(byteArray.getRange(0, length).toList().reversed);
+    return List<int>.from(byteArray.getRange(0, length).toList());
   }
 
   static String dataToBinaryFlags(intArray, {int count = 2}) {

--- a/test/ftms/characteristic/machine/control_point/machine_control_point_test.dart
+++ b/test/ftms/characteristic/machine/control_point/machine_control_point_test.dart
@@ -18,4 +18,12 @@ void main() {
     expect(controlPoint.opCode.type, MachineControlPointOpcodeType.stopOrPause);
     expect(controlPoint.getWriteData(), [0x8, 0x2]);
   });
+
+  test("test machine control point with Target Power", () {
+    var controlPoint = MachineControlPoint.setTargetPower(power: 300);
+
+    expect(controlPoint.opCode.value, 0x5);
+    expect(controlPoint.opCode.type, MachineControlPointOpcodeType.setTargetPower);
+    expect(controlPoint.getWriteData(), [0x5, 0x2C,0x01]);
+  });
 }


### PR DESCRIPTION
Hi, I'm using your library with indoor trainers. 

Indoor trainer was not respondingo correctly to setting power, so I found that array values was revesed, and then removed the reversed from your function. 

After removing it, Indoor trainer started to wrork correctly.

The indoor trainer I'm using works fine with other apps/programs like Zwift, Rouvy ecc..

I'm sorry for my bad english
 Thank you